### PR TITLE
Improve moduleNameMapper example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Jest doesn't apply transforms to node_modules by default. You can solve this by 
   "jest": {
     // ..
     "moduleNameMapper": {
-      "^.+.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "jest-transform-stub"
+      "^.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$": "jest-transform-stub"
     }
   }
 }


### PR DESCRIPTION
With the previous version of regexp, it is possible to match not intended modules, for example [caseless]( https://www.npmjs.com/package/caseless) with `.less` part of the previous regexp.

This change and the new regexp fixes this problem.